### PR TITLE
Htslib warnings

### DIFF
--- a/contrib/htslib/bgzf.c
+++ b/contrib/htslib/bgzf.c
@@ -731,8 +731,8 @@ int bgzf_flush_try(BGZF *fp, ssize_t size)
 
 ssize_t bgzf_write(BGZF *fp, const void *data, size_t length)
 {
-    if ( !fp->is_compressed )
-        return hwrite(fp->fp, data, length);
+	if ( !fp->is_compressed )
+		return hwrite(fp->fp, data, length);
 
 	const uint8_t *input = (const uint8_t*)data;
 	ssize_t remaining = length;

--- a/contrib/htslib/cram/cram_encode.c
+++ b/contrib/htslib/cram/cram_encode.c
@@ -2165,6 +2165,7 @@ static int process_one_read(cram_fd *fd, cram_container *c,
 	cr->rg = brg ? brg->id : -1;
     } else if (fd->version == CRAM_1_VERS) {
 	SAM_RG *brg = sam_hdr_find_rg(fd->header, "UNKNOWN");
+  (void)brg; //Suppress unused variable warning
 	assert(brg);
     } else {
 	cr->rg = -1;

--- a/contrib/htslib/cram/cram_index.c
+++ b/contrib/htslib/cram/cram_index.c
@@ -426,7 +426,7 @@ static int cram_index_build_multiref(cram_fd *fd,
  */
 int cram_index_build(cram_fd *fd, const char *fn_base) {
     cram_container *c;
-    off_t cpos, spos, hpos;
+    off_t cpos, spos;
     zfp *fp;
     char fn_idx[PATH_MAX];
 
@@ -448,7 +448,8 @@ int cram_index_build(cram_fd *fd, const char *fn_base) {
             return 1;
         }
 
-        hpos = htell(fd->fp);
+        off_t hpos = htell(fd->fp);
+        (void)hpos; //Suppress unused variable warning
 
         if (!(c->comp_hdr_block = cram_read_block(fd)))
             return 1;

--- a/contrib/htslib/cram/cram_io.c
+++ b/contrib/htslib/cram/cram_io.c
@@ -48,6 +48,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "io_lib_config.h"
 #endif
 
+#ifdef __linux__ 
+#include <unistd.h>
+#endif
+
 #include <stdio.h>
 #include <errno.h>
 #include <assert.h>

--- a/contrib/htslib/cram/vlen.c
+++ b/contrib/htslib/cram/vlen.c
@@ -121,6 +121,8 @@ int vflen(char *fmt, va_list ap)
     int i;
     double d; 
 
+    (void)i; //Suppress unused variable error
+
     /*
      * This code modifies 'ap', but we do not know if va_list is a structure
      * or a pointer to an array so we do not know if it is a local variable

--- a/contrib/htslib/faidx.c
+++ b/contrib/htslib/faidx.c
@@ -252,19 +252,21 @@ faidx_t *fai_load(const char *fn)
 	sprintf(str, "%s.fai", fn);
 
 #ifdef _USE_KNETFILE
-    if (strstr(fn, "ftp://") == fn || strstr(fn, "http://") == fn)
-    {
-        fp = download_and_open(str);
-        if ( !fp )
-        {
-            fprintf(stderr, "[fai_load] failed to open remote FASTA index %s\n", str);
-            free(str);
-            return 0;
-        }
-    }
-    else
+  if (strstr(fn, "ftp://") == fn || strstr(fn, "http://") == fn)
+  {
+      fp = download_and_open(str);
+      if ( !fp )
+      {
+          fprintf(stderr, "[fai_load] failed to open remote FASTA index %s\n", str);
+          free(str);
+          return 0;
+      }
+  } else {
+    fp = fopen(str, "rb");
+  }
+#else
+  fp = fopen(str, "rb");
 #endif
-        fp = fopen(str, "rb");
 	if (fp == 0) {
 		fprintf(stderr, "[fai_load] build FASTA index.\n");
 		fai_build(fn);

--- a/contrib/htslib/htslib/hts.h
+++ b/contrib/htslib/htslib/hts.h
@@ -4,6 +4,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __linux__ 
+#include <unistd.h>
+#endif
+
 #ifndef HTS_BGZF_TYPEDEF
 typedef struct BGZF BGZF;
 #define HTS_BGZF_TYPEDEF

--- a/contrib/htslib/vcf.c
+++ b/contrib/htslib/vcf.c
@@ -1958,7 +1958,7 @@ int vcf_format(const bcf_hdr_t *h, const bcf1_t *v, kstring_t *s)
         for (i = 0; i < v->n_info; ++i) {
             bcf_info_t *z = &v->d.info[i];
             if ( !z->vptr ) continue;
-            if ( !first ) kputc(';', s); first = 0;
+            if ( !first ) { kputc(';', s); } first = 0;
             kputs(h->id[BCF_DT_ID][z->key].key, s);
             if (z->len <= 0) continue;
             kputc('=', s);
@@ -1997,7 +1997,7 @@ int vcf_format(const bcf_hdr_t *h, const bcf1_t *v, kstring_t *s)
                 for (i = 0; i < (int)v->n_fmt; ++i) {
                     bcf_fmt_t *f = &fmt[i];
                     if ( !f->p ) continue;
-                    if (!first) kputc(':', s); first = 0;
+                    if (!first) { kputc(':', s); } first = 0;
                     if (gt_i == i)
                         bcf_format_gt(f,j,s);
                     else


### PR DESCRIPTION
Eliminates warnings in htslib without replacing it (seems like the most recent version has a compilation issue on GCC6, so that'll have to wait).